### PR TITLE
modern: Update scripts to Python 3

### DIFF
--- a/battle-e/Makefile
+++ b/battle-e/Makefile
@@ -9,7 +9,7 @@ SERIES_2_BERRIES = ginema kuo yago touga niniku topo
 PROMO_EN_NUMS = B001 B002
 PROMO_EN_TRAINERS = astrid nils
 P_PROMO_NUMS = P001 P002 P003 P004 P005 P006 P007 P008
-P_PROMO_TRAINERS = craig yasuo darlene mattego hidehiko yufu sagami mattegoDEMO 
+P_PROMO_TRAINERS = craig yasuo darlene mattego hidehiko yufu sagami mattegoDEMO
 N_PROMO_NUMS = N001 N002 N003 N004 N005 N006 N007 N008
 N_PROMO_TRAINERS = teruko kimiko norton simon hozumi ritsue yuuma taisen
 
@@ -26,124 +26,124 @@ verify:
 
 
 trainers/%-EN.tx: trainers/%.asm
-	python ../scripts/regionalize.py $< $@ EN EN
+	python3 ../scripts/regionalize.py $< $@ EN EN
 trainers/%.o: trainers/%.tx
 	./rgbasm.exe -o $@ $<
 trainers/%.gbc: trainers/%.o
 	./rgblink.exe -o $@ $<
 trainers/%.bin: trainers/%.gbc
-	python ../scripts/stripgbc.py $< $@
+	python3 ../scripts/stripgbc.py $< $@
 trainers/%.z80: trainers/%.gbc
-	python ../scripts/stripgbc.py $< $@
+	python3 ../scripts/stripgbc.py $< $@
 trainers/%.mev: trainers/%.bin
-	python ../scripts/checksum.py $< $@
+	python3 ../scripts/checksum.py $< $@
 
 
 berries/%-EN.tx: berries/%.asm
-	python ../scripts/regionalize.py $< $@ EN EN
+	python3 ../scripts/regionalize.py $< $@ EN EN
 berries/%.o: berries/%.tx
 	./rgbasm.exe -o $@ $<
 berries/%.gbc: berries/%.o
 	./rgblink.exe -o $@ $<
 berries/%.bin: berries/%.gbc
-	python ../scripts/stripgbc.py $< $@
+	python3 ../scripts/stripgbc.py $< $@
 berries/%.z80: berries/%.gbc
-	python ../scripts/stripgbc.py $< $@
+	python3 ../scripts/stripgbc.py $< $@
 berries/%.mev: berries/%.bin
-	python ../scripts/checksum.py $< $@
+	python3 ../scripts/checksum.py $< $@
 
 
 prologue-%.tx: prologue.asm
-	python ../scripts/regionalize.py $< $@ $* $*
+	python3 ../scripts/regionalize.py $< $@ $* $*
 prologue-%.o: prologue-%.tx
 	./rgbasm.exe -o $@ $<
 prologue-%.gbc: prologue-%.o
 	./rgblink.exe -o $@ $<
 prologue-%.bin: prologue-%.gbc
-	python ../scripts/stripgbc.py $< $@
+	python3 ../scripts/stripgbc.py $< $@
 
 
 battletrainer-%.tx: battletrainer.asm prologue-%.bin
-	python ../scripts/ereadertext.py $< $@ $*
+	python3 ../scripts/ereadertext.py $< $@ $*
 08-A%-EN.tx: 08-A%.asm battletrainer-EN.tx
-	python ../scripts/ereadertext.py $< $@ EN
+	python3 ../scripts/ereadertext.py $< $@ EN
 08-A%.o: 08-A%.tx
 	./rgbasm.exe -o $@ $<
 08-A%.gbc: 08-A%.o
 	./rgblink.exe -o $@ $<
 08-A%.z80: 08-A%.gbc
-	python ../scripts/stripgbc.py $< $@
+	python3 ../scripts/stripgbc.py $< $@
 08-A%.vpk: 08-A%.z80
 	./nevpk.exe -c -i $< -o $@
 08-A%.raw: 08-A%.vpk
 	./nedcmake.exe -i $< -o $@ -type 1 -region 1
 
 08-B%-EN.tx: 08-B%.asm battletrainer-EN.tx
-	python ../scripts/ereadertext.py $< $@ EN
+	python3 ../scripts/ereadertext.py $< $@ EN
 08-B%.o: 08-B%.tx
 	./rgbasm.exe -o $@ $<
 08-B%.gbc: 08-B%.o
 	./rgblink.exe -o $@ $<
 08-B%.z80: 08-B%.gbc
-	python ../scripts/stripgbc.py $< $@
+	python3 ../scripts/stripgbc.py $< $@
 08-B%.vpk: 08-B%.z80
 	./nevpk.exe -c -i $< -o $@
 08-B%.raw: 08-B%.vpk
-	./nedcmake.exe -i $< -o $@ -type 1 -region 1		
+	./nedcmake.exe -i $< -o $@ -type 1 -region 1
 
 129-B%-EN.tx: 129-B%.asm battletrainer-EN.tx
-	python ../scripts/ereadertext.py $< $@ EN
+	python3 ../scripts/ereadertext.py $< $@ EN
 129-B%.o: 129-B%.tx
 	./rgbasm.exe -o $@ $<
 129-B%.gbc: 129-B%.o
 	./rgblink.exe -o $@ $<
 129-B%.z80: 129-B%.gbc
-	python ../scripts/stripgbc.py $< $@
+	python3 ../scripts/stripgbc.py $< $@
 129-B%.vpk: 129-B%.z80
 	./nevpk.exe -c -i $< -o $@
 129-B%.raw: 129-B%.vpk
 	./nedcmake.exe -i $< -o $@ -type 1 -region 1
-	
+
 enigmaberry-%.tx: enigmaberry.asm prologue-%.bin
-	python ../scripts/ereadertext.py $< $@ $*
+	python3 ../scripts/ereadertext.py $< $@ $*
 08-K%-EN.tx: 08-K%.asm enigmaberry-EN.tx
-	python ../scripts/ereadertext.py $< $@ EN
+	python3 ../scripts/ereadertext.py $< $@ EN
 08-K%.o: 08-K%.tx
 	./rgbasm.exe -o $@ $<
 08-K%.gbc: 08-K%.o
 	./rgblink.exe -o $@ $<
 08-K%.z80: 08-K%.gbc
-	python ../scripts/stripgbc.py $< $@
+	python3 ../scripts/stripgbc.py $< $@
 08-K%.vpk: 08-K%.z80
 	./nevpk.exe -c -i $< -o $@
 08-K%.raw: 08-K%.vpk
-	./nedcmake.exe -i $< -o $@ -type 1 -region 1 -raw	
-	
+	./nedcmake.exe -i $< -o $@ -type 1 -region 1 -raw
+
 08-N%-EN.tx: 08-N%.asm battletrainer-EN.tx
-	python ../scripts/ereadertext.py $< $@ EN
+	python3 ../scripts/ereadertext.py $< $@ EN
 08-N%.o: 08-N%.tx
 	./rgbasm.exe -o $@ $<
 08-N%.gbc: 08-N%.o
 	./rgblink.exe -o $@ $<
 08-N%.z80: 08-N%.gbc
-	python ../scripts/stripgbc.py $< $@
+	python3 ../scripts/stripgbc.py $< $@
 08-N%.vpk: 08-N%.z80
 	./nevpk.exe -c -i $< -o $@
 08-N%.raw: 08-N%.vpk
-	./nedcmake.exe -i $< -o $@ -type 1 -region 1		
-	
+	./nedcmake.exe -i $< -o $@ -type 1 -region 1
+
 08-P%-EN.tx: 08-P%.asm battletrainer-EN.tx
-	python ../scripts/ereadertext.py $< $@ EN
+	python3 ../scripts/ereadertext.py $< $@ EN
 08-P%.o: 08-P%.tx
 	./rgbasm.exe -o $@ $<
 08-P%.gbc: 08-P%.o
 	./rgblink.exe -o $@ $<
 08-P%.z80: 08-P%.gbc
-	python ../scripts/stripgbc.py $< $@
+	python3 ../scripts/stripgbc.py $< $@
 08-P%.vpk: 08-P%.z80
 	./nevpk.exe -c -i $< -o $@
 08-P%.raw: 08-P%.vpk
-	./nedcmake.exe -i $< -o $@ -type 1 -region 1	
+	./nedcmake.exe -i $< -o $@ -type 1 -region 1
 
 
 clean:

--- a/scripts/asmquote.py
+++ b/scripts/asmquote.py
@@ -28,20 +28,10 @@ def asmQuote(t):
 	return result
 
 def asmQuoteBytes(t):
-	og_q = asmQuote(t)
-	og_b = ""
-	for b in og_q.replace('",0,"', '\x00').replace('"', '').replace(',0', '\x00'):
-		og_b += hex(ord(b))
-
 	result = ""
-	test = ""
 	for b in t:
 		result += '{0}'.format(ord(b)) + ","
-		test += hex(ord(b))
 
 	result = result[:-1]
-
-	if og_b != test:
-		print("WARN:", og_q, og_b, test)
 
 	return result

--- a/scripts/asmquote.py
+++ b/scripts/asmquote.py
@@ -26,3 +26,22 @@ def asmQuote(t):
 	if quoted:
 		result += '"'
 	return result
+
+def asmQuoteBytes(t):
+	og_q = asmQuote(t)
+	og_b = ""
+	for b in og_q.replace('",0,"', '\x00').replace('"', '').replace(',0', '\x00'):
+		og_b += hex(ord(b))
+
+	result = ""
+	test = ""
+	for b in t:
+		result += '{0}'.format(ord(b)) + ","
+		test += hex(ord(b))
+
+	result = result[:-1]
+
+	if og_b != test:
+		print("WARN:", og_q, og_b, test)
+
+	return result

--- a/scripts/checksum.py
+++ b/scripts/checksum.py
@@ -11,7 +11,6 @@ wordwise_results = []
 crcs = []
 crc_results = []
 
-data = None
 with open(sys.argv[1], 'rb') as f:
 	data = f.read()
 f.closed

--- a/scripts/checksum.py
+++ b/scripts/checksum.py
@@ -11,7 +11,7 @@ wordwise_results = []
 crcs = []
 crc_results = []
 
-data = ""
+data = None
 with open(sys.argv[1], 'rb') as f:
 	data = f.read()
 f.closed
@@ -19,7 +19,7 @@ f.closed
 base_address = struct.unpack('<I', data[1:5])[0]
 i = 0x11 # first chunk location
 while i < len(data):
-	chunk_type = ord(data[i])
+	chunk_type = data[i]
 	if chunk_type == 0x02: # END_OF_CHUNKS
 		break
 	elif chunk_type == 0x07: # CUSTOM_BERRY
@@ -37,7 +37,7 @@ while i < len(data):
 		end_address = struct.unpack('<I', data[i+9:i+13])[0] - base_address
 		crcs.append([i + 1, start_address, end_address])
 	elif chunk_type < 0x02 or chunk_type > 0x10:
-		print "Unknown chunk {0:X}".format(chunk_type)
+		print("Unknown chunk {0:X}".format(chunk_type))
 		raise TypeError
 	i += chunk_lengths[chunk_type]
 
@@ -58,7 +58,7 @@ for wordwise in wordwises:
 for bytewise in bytewises:
 	sum = 0
 	for i in range(bytewise[1], bytewise[2]):
-		sum = (sum + ord(data[i])) & 0xFFFFFFFF
+		sum = (sum + data[i]) & 0xFFFFFFFF
 	bytewise_results.append(sum)
 i = 0
 for bytewise in bytewises:
@@ -70,7 +70,7 @@ for bytewise in bytewises:
 for crc in crcs:
 	sum = 0x1121
 	for i in range(crc[1], crc[2]):
-		sum ^= ord(data[i])
+		sum ^= data[i]
 		for j in range(8):
 			if(sum & 1):
 				sum = (sum >> 1) ^ 0x8408
@@ -86,5 +86,5 @@ for crc in crcs:
 
 
 # write the updated file
-out = open(sys.argv[2], 'w')
+out = open(sys.argv[2], 'wb')
 out.write(data)

--- a/scripts/checksum_regi.py
+++ b/scripts/checksum_regi.py
@@ -52,7 +52,7 @@ for i in pos:
 		start_address = struct.unpack('<I', data[i+1:i+5])[0] - base_address
 		wordwises.append([start_address + 0x13C, start_address, start_address + 0x13C])
 	elif chunk_type < 0x02 or chunk_type > 0x11:
-		print "Unknown chunk {0:X}".format(chunk_type)
+		print("Unknown chunk {0:X}".format(chunk_type))
 		raise TypeError
 	i += chunk_lengths[chunk_type]
 

--- a/scripts/ereadertext.py
+++ b/scripts/ereadertext.py
@@ -7,7 +7,7 @@ region = sys.argv[3]
 
 out = open(sys.argv[2], 'w')
 
-with open(sys.argv[1], 'rb') as f:
+with open(sys.argv[1], 'r') as f:
 	for asm in f:
 		asms = asm.split('"')
 		command = asms[0].strip()
@@ -17,7 +17,7 @@ with open(sys.argv[1], 'rb') as f:
 			asms[1] = asms[1].replace('\\n', '\n')
 			asms[1] = asms[1].replace('é', '\x7F')
 
-			out.write("db " + asmQuote(asms[1]) + "\n")
+			out.write("\tdb " + asmQuote(asms[1]) + "\n")
 		else:
 			out.write(asm)
 			if "macros.asm" in asm:

--- a/scripts/gen3text.py
+++ b/scripts/gen3text.py
@@ -431,27 +431,7 @@ def utf8ToRSText(t, region = ""):
 	if region == "DE":
 		chars['“'] = '\xB2'
 
-#	characters = []
-#	char = ""
-#	while len(t):
-#		if ord(t[0]) >= 0xF0:
-#			char += t[0:4]
-#			t = t[4:]
-#		elif ord(t[0]) >= 0xE0:
-#			char += t[0:3]
-#			t = t[3:]
-#		elif ord(t[0]) >= 0xC0:
-#			char += t[0:2]
-#			t = t[2:]
-#		else:
-#			char += t[0:1]
-#			t = t[1:]
-#		if char != "\\" and char != "\\v" and (char[0:2] != "\\{" or char[-1] == "}"):
-#			characters.append(char)
-#			char = ""
-
 	result = ""
-#	for char in characters:
 	for char in t:
 		result += chars[char]
 	return result

--- a/scripts/gen3text.py
+++ b/scripts/gen3text.py
@@ -431,27 +431,28 @@ def utf8ToRSText(t, region = ""):
 	if region == "DE":
 		chars['“'] = '\xB2'
 
-	characters = []
-	char = ""
-	while len(t):
-		if ord(t[0]) >= 0xF0:
-			char += t[0:4]
-			t = t[4:]
-		elif ord(t[0]) >= 0xE0:
-			char += t[0:3]
-			t = t[3:]
-		elif ord(t[0]) >= 0xC0:
-			char += t[0:2]
-			t = t[2:]
-		else:
-			char += t[0:1]
-			t = t[1:]
-		if char != "\\" and char != "\\v" and (char[0:2] != "\\{" or char[-1] == "}"):
-			characters.append(char)
-			char = ""
+#	characters = []
+#	char = ""
+#	while len(t):
+#		if ord(t[0]) >= 0xF0:
+#			char += t[0:4]
+#			t = t[4:]
+#		elif ord(t[0]) >= 0xE0:
+#			char += t[0:3]
+#			t = t[3:]
+#		elif ord(t[0]) >= 0xC0:
+#			char += t[0:2]
+#			t = t[2:]
+#		else:
+#			char += t[0:1]
+#			t = t[1:]
+#		if char != "\\" and char != "\\v" and (char[0:2] != "\\{" or char[-1] == "}"):
+#			characters.append(char)
+#			char = ""
 
 	result = ""
-	for char in characters:
+#	for char in characters:
+	for char in t:
 		result += chars[char]
 	return result
 

--- a/scripts/regionalize.py
+++ b/scripts/regionalize.py
@@ -1,14 +1,14 @@
 # -*- coding: utf-8 -*-
 import sys
 from gen3text import utf8ToRSText
-from asmquote import asmQuote
+from asmquote import asmQuoteBytes
 
 data_region = sys.argv[3] # determines region code
 text_region = sys.argv[4] # determines string translation
 
 out = open(sys.argv[2], 'w')
 
-with open(sys.argv[1], 'rb') as f:
+with open(sys.argv[1], 'r') as f:
 	for asm in f:
 		asms = asm.split('"')
 		command = asms[0].strip()
@@ -23,7 +23,7 @@ with open(sys.argv[1], 'rb') as f:
 					asms[1] += "\x00"
 			except ValueError:
 				pass
-			out.write("db " + asmQuote(asms[1]) + "\n")
+			out.write("\tdb " + asmQuoteBytes(asms[1]) + "\n")
 		elif len(command) < 5 or command[0:5] != "Text_":
 			out.write(asm)
 			if "macros.asm" in asm:

--- a/scripts/stripgbc.py
+++ b/scripts/stripgbc.py
@@ -14,11 +14,9 @@ with open(sys.argv[1], 'rb') as f:
 
 		# the program shall end with $FF followed only by $00 bytes
 		# for every $FF we hit, buffer until something that isn’t $00
-		if not buffering and ord(byte) == 0xFF:
+		if (not buffering and ord(byte) == 0xFF) or (buffering and ord(byte) == 0x00):
 			buf += byte
 			buffering = True
-		elif buffering and ord(byte) == 0x00:
-			buf += byte
 		elif buffering and ord(byte) == 0xFF:
 			out.write(buf)
 			buf = byte

--- a/scripts/stripgbc.py
+++ b/scripts/stripgbc.py
@@ -2,9 +2,9 @@
 #!/usr/bin/env python2.7
 import sys
 
-out = open(sys.argv[2], 'w')
+out = open(sys.argv[2], 'wb')
 buffering = False
-buf = ""
+buf = bytes()
 with open(sys.argv[1], 'rb') as f:
 	f.read(256) # skip to $0100
 	while True:
@@ -14,16 +14,18 @@ with open(sys.argv[1], 'rb') as f:
 
 		# the program shall end with $FF followed only by $00 bytes
 		# for every $FF we hit, buffer until something that isn’t $00
-		if (not buffering and ord(byte) == 0xFF) or (buffering and ord(byte) == 0x00):
+		if not buffering and ord(byte) == 0xFF:
 			buf += byte
 			buffering = True
+		elif buffering and ord(byte) == 0x00:
+			buf += byte
 		elif buffering and ord(byte) == 0xFF:
 			out.write(buf)
 			buf = byte
 		elif buffering:
 			out.write(buf)
 			out.write(byte)
-			buf = ""
+			buf = bytes()
 			buffering = False
 		else:
 			out.write(byte)


### PR DESCRIPTION
This change updates the scripts to work with Python3. Python2.7 is long since EOL and very difficult to source on modern operating systems.

The auto 2to3 script wasn't much help, all it did was adding missing `( )` around prints but for the most part not a lot of changes were needed. Primary issues were around opening files as binary and general unicode headaches.

Some non trivial edits were needed to make the full toolchain work again under the new system
